### PR TITLE
fix: firefox adds "keep-alive" in ws connection headers

### DIFF
--- a/src/happyx/ssr/server.nim
+++ b/src/happyx/ssr/server.nim
@@ -818,7 +818,7 @@ socketToSsr.onmessage=function(m){
         ),
         newCall(
           "and",
-          newCall("==", newCall("toLower", newCall("[]", headers, newStrLitNode("connection"), newLit(0))), newStrLitNode("upgrade")),
+          newCall("contains", newCall("[]", headers, newStrLitNode("connection")), newStrLitNode("upgrade")),
           newCall("==", newCall("toLower", newCall("[]", headers, newStrLitNode("upgrade"), newLit(0))), newStrLitNode("websocket")),
         )
       )


### PR DESCRIPTION
I believe this fixes the issue mentionned in https://github.com/HapticX/happyx/issues/142

Btw I removed the explicit call to `toLower` since it is already included in https://nim-lang.org/docs/httpcore.html#contains%2CHttpHeaderValues%2Cstring