### PR TITLE
split form data items with `strutils.split` to prevent `AssertionDefect` in regex package

### DIFF
--- a/src/happyx/ssr/form_data.nim
+++ b/src/happyx/ssr/form_data.nim
@@ -41,7 +41,7 @@ proc parseFormData*(formData: string): (StringTableRef, TableRef[string, FormDat
   result = (newStringTable(), newTable[string, FormDataItem]())
   let
     formDataSeparator = re2"\-{6}\w+(\-{2})?\r\n"
-    lineSeparator = re2"\r\n"  
+    lineSeparator = "\r\n"
     data = formData.split(formDataSeparator)
   for item in data:
     let lines = item.split(lineSeparator)


### PR DESCRIPTION
When using `regex.split` to split form data, if it contains binary files, it may raise an `AssertionDefect`. This patch replace it with `strutils.split`.