### PR TITLE
fix formDataSeparator regex, skip empty lines

### DIFF
--- a/src/happyx/ssr/form_data.nim
+++ b/src/happyx/ssr/form_data.nim
@@ -40,7 +40,7 @@ proc parseFormData*(formData: string): (StringTableRef, TableRef[string, FormDat
   ## Parses `form-data` into `StringTableRef`
   result = (newStringTable(), newTable[string, FormDataItem]())
   let
-    formDataSeparator = re2"\-{6}\w+(\-{2})?\r\n"
+    formDataSeparator = re2"\-{2,}\w+(\-{2})?\r\n"
     lineSeparator = "\r\n"
     data = formData.split(formDataSeparator)
   for item in data:
@@ -52,6 +52,7 @@ proc parseFormData*(formData: string): (StringTableRef, TableRef[string, FormDat
       contentType = ""
       i = 0
     for line in lines:
+      if line == "": continue
       if line.startsWith("Content-Disposition"):
         # every param
         for param in line.split(re2"\s*;\s*"):


### PR DESCRIPTION
Please, check that your changes follow the guidelines below:

* [x] Are you following the [Nim Style Guide](https://nim-lang.org/docs/nep1.html)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?


## If this PR fixes a bug ...

Fix for https://github.com/HapticX/happyx/issues/286

Fixed boundary delimiter handling according to RFC 2046 (https://datatracker.ietf.org/doc/html/rfc2046)
```
   The Content-Type field for multipart entities requires one parameter,
   "boundary". The boundary delimiter line is then defined as a line
   consisting entirely of two hyphen characters ("-", decimal value 45)
   followed by the boundary parameter value from the Content-Type header
   field, optional linear whitespace, and a terminating CRLF.
```

Also fixed handling of empty lines resulting from splitting items by line separators. This leads to file content being written correctly. Before the fix, there were empty lines in the received files, which did not belong there. It was not explicitly mentioned in the bug ticket #286, but it is clearly visible in the example.

Code was tested with multiple text files, json and regular key-value pairs.
