### PR TITLE
upgrade regCORS

### DIFF
--- a/happyx.nimble
+++ b/happyx.nimble
@@ -2,7 +2,7 @@
 
 description = "Macro-oriented asynchronous web-framework written with ♥"
 author = "HapticX"
-version = "4.5.1"
+version = "4.5.2"
 license = "MIT"
 srcDir = "src"
 installExt = @["nim"]

--- a/src/happyx/core/constants.nim
+++ b/src/happyx/core/constants.nim
@@ -100,7 +100,7 @@ const
   # Framework version
   HpxMajor* = 4
   HpxMinor* = 5
-  HpxPatch* = 1
+  HpxPatch* = 2
   HpxVersion* = $HpxMajor & "." & $HpxMinor & "." & $HpxPatch
 
 

--- a/src/happyx/ssr/cors.nim
+++ b/src/happyx/ssr/cors.nim
@@ -46,11 +46,18 @@ when not defined(js) and not (exportJvm or exportPython or defined(napibuild)):
         `headers`["Access-Control-Allow-Headers"] = `allowHeaders`
     if allowMethods.len > 0:
       if allowMethods == "*":
-        result.add quote do:
-          if req.reqMethod == HttpOptions:
-            `headers`["Access-Control-Allow-Methods"] = "OPTIONS"
-          else:
-            `headers`["Access-Control-Allow-Methods"] = $req.reqMethod & ",OPTIONS"
+        when not enableHttpx and not enableHttpBeast:
+          result.add quote do:
+            if req.reqMethod == HttpOptions:
+              `headers`["Access-Control-Allow-Methods"] = "OPTIONS"
+            else:
+              `headers`["Access-Control-Allow-Methods"] = $req.reqMethod & ",OPTIONS"
+        else:
+          result.add quote do:
+            if req.httpMethod.get() == HttpOptions:
+              `headers`["Access-Control-Allow-Methods"] = "OPTIONS"
+            else:
+              `headers`["Access-Control-Allow-Methods"] = $req.httpMethod.get() & ",OPTIONS"
       else:
         result.add quote do:
           `headers`["Access-Control-Allow-Methods"] = `allowMethods`

--- a/src/happyx/ssr/server.nim
+++ b/src/happyx/ssr/server.nim
@@ -1154,12 +1154,12 @@ macro routes*(server: Server, body: untyped = newStmtList()): untyped =
       "handleJvmRequest", ident"self", ident"req", ident"urlPath"
     ))
 
-  # when not (exportPython or exportJvm or defined(napibuild)):
-  #   var returnStmt = newStmtList(newNimNode(nnkReturnStmt).add(newLit""))
-  #   detectReturnStmt(returnStmt)
-  #   methodTable.mgetOrPut(
-  #     "OPTIONS", newNimNode(nnkIfStmt)
-  #   ).add(exportRouteArgs(pathIdent, newLit"/{p:path}", returnStmt))
+  when not (exportPython or exportJvm or defined(napibuild)):
+    var returnStmt = newStmtList(newNimNode(nnkReturnStmt).add(newLit""))
+    detectReturnStmt(returnStmt)
+    methodTable.mgetOrPut(
+      "OPTIONS", newNimNode(nnkIfStmt)
+    ).add(exportRouteArgs(pathIdent, newLit"/{p:path}", returnStmt))
 
   for key in methodTable.keys():
     caseRequestMethodsStmt.add(newNimNode(nnkOfBranch).add(

--- a/tests/testc6.nim
+++ b/tests/testc6.nim
@@ -3,10 +3,17 @@ import
   macros
 
 
+# regCORS:
+#   credentials: true
+#   origins: "*" # "https://www.google.com"  # You can send request from this address
+#   methods: ["GET", "POST", "PUT"]
+#   headers: "*"
+
+
 regCORS:
   credentials: true
-  origins: "*" # "https://www.google.com"  # You can send request from this address
-  methods: ["GET", "POST", "PUT"]
+  origins: "*"
+  methods: "*"
   headers: "*"
 
 


### PR DESCRIPTION
Now CORS is easier to configure:

```nim
regCORS:
  credentials: true
  origins: "*"
  methods: "*"
  headers: "*"
```

Some examples of headers in response:
Request: `OPTIONS /`
```http
HTTP/1.1 200 OK
access-control-allow-credentials: true
access-control-allow-methods: OPTIONS
content-type: text/plain; charset=utf-8
access-control-allow-origin: https://www.wildberries.ru
access-control-allow-headers: *
Content-Length: 0
```

Request `GET /`
```http
HTTP/1.1 200 OK
access-control-allow-credentials: true
access-control-allow-methods: GET,OPTIONS
content-type: text/plain; charset=utf-8
access-control-allow-origin: https://www.wildberries.ru
access-control-allow-headers: *
Content-Length: 13
```

Request `GET /` with `-d:httpx`
```http
HTTP/1.1 200
Content-Length: 13
Server: Nim-HTTPX
Date: Thu, 12 Sep 2024 16:54:04 GMT
access-control-allow-credentials: true
access-control-allow-methods: GET,OPTIONS
content-type: text/plain; charset=utf-8
access-control-allow-origin: https://tailwindcss.com
access-control-allow-headers: *
```